### PR TITLE
Auto-scale disk size based on inputs

### DIFF
--- a/vcf_merge.wdl
+++ b/vcf_merge.wdl
@@ -6,12 +6,16 @@ task xVCFMerge {
         String output_file
         String billing_project
         String workspace
+        Int? addl_disk_space = 1
         Int? cpu = 8
         Int? memory = 64
         Int? preemptible = 0
     }
+    Int input_size = ceil(size(input_files, "GB"))
+    Int final_disk_size = input_size + addl_disk_space
     runtime {
         docker: "xbrianh/xsamtools:v0.5.2"
+        disks: "local-disk " + final_disk_size + " HDD"
         memory: "${memory}G"
         cpu: "${cpu}"
         preemptible: "${preemptible}"


### PR DESCRIPTION
If the disk size argument is not given, which is what this pipeline does by default, then the disk size defaults to about 10 GB and anything above that will error out. Because xvcfmerge works differently then most workflows though, I am not quite sure if adding this will actually matter, so feel free to close this if it's basically a no-op.

R/e the new optional argument: The additional disk space argument is more useful in some workflows than others. For our purposes I presume it is overkill, but imho it is good practice to include.

Passes on Terra.