### PR TITLE
*Partially* fix issues with testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ plugin:
 	pip install --upgrade --no-cache-dir tests/infra/inject_gs_credentials
 
 lint:
-	miniwdl check vcf_merge.wdl
+	miniwdl check vcf_merge.wdl --suppress FileCoercion
 
 clean:
 	git clean -dfx

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Terra workspace and GCP authorization.
 
 To run basic tests,
 ```
+docker login
 gcloud auth login
 make test
 ```

--- a/vcf_merge.wdl
+++ b/vcf_merge.wdl
@@ -6,10 +6,10 @@ task xVCFMerge {
         String output_file
         String billing_project
         String workspace
-        Int? addl_disk_space = 1
-        Int? cpu = 8
-        Int? memory = 64
-        Int? preemptible = 0
+        Int addl_disk_space = 1
+        Int cpu = 8
+        Int memory = 64
+        Int preemptible = 0
     }
     Int input_size = ceil(size(input_files, "GB"))
     Int final_disk_size = input_size + addl_disk_space
@@ -33,9 +33,9 @@ workflow xVCFMergeWorkflow {
         String output_file
         String billing_project
         String workspace
-        Int? cpu = 8
-        Int? memory = 64
-        Int? preemptible = 0
+        Int? cpu
+        Int? memory
+        Int? preemptible
     }
     call xVCFMerge { input: input_files=input_files,
                             output_file=output_file,


### PR DESCRIPTION
I originally tested my changes r/e disk size on Cromwell, not miniwdl, as support for Cromwell is vital for a WDL that is designed to run in Terra. Still, my changes should also work with the tests in the makefile, right? 

TL;DR - It turns out miniwdl handles types used in the file size workaround differently from Cromwell. 
* Cromwell considers adding an Int? and an Int together to be valid provided the Int? always has an actual value; miniwdl considers it an IncompatibleOperand error. (This discrepancy seems to be due to two different interpretations of the openWDL spec, see https://github.com/chanzuckerberg/miniwdl/issues/523) --> fixed in this PR by declaring them required instead of optional, since they're getting default values anyway
* miniwdl does not like it when you call size() on an array of files, even though this is, as far as I'm aware, the only way to your WDL's disk size to scale based on the size of your inputs in WDL 1.0 --> that particular warning gets suppressed in the makefile now
* (also added a line to the readme telling the user to `docker login` because I forgot to do that and docker hub got very mad when miniwdl tried to pull the xsamtools image)

There is one remaining problem though...
Although the gs plugin here does download files correctly, and after authenticating miniwdl does report that the files successfully downloaded, it seems the plugin does not help miniwdl handle the size() function. This *could* be handwaved by just commenting out the disk size related parts of the code before running the makefile, since you don't need those arguments if you are running locally, and if you do that then everything passes... but that feels gross.