### PR TITLE
More bcftools args

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ plugin:
 	pip install --upgrade --no-cache-dir tests/infra/inject_gs_credentials
 
 lint:
-	miniwdl check vcf_merge.wdl
+	miniwdl check vcf_merge.wdl --suppress FileCoercion
 
 clean:
 	git clean -dfx

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Terra workspace and GCP authorization.
 
 To run basic tests,
 ```
+docker login
 gcloud auth login
 make test
 ```

--- a/vcf_merge.wdl
+++ b/vcf_merge.wdl
@@ -48,17 +48,11 @@ workflow xVCFMergeWorkflow {
         String workspace
         Boolean? force_samples
         Boolean? print_header
-        Int? cpu
-        Int? memory
-        Int? preemptible
     }
     call xVCFMerge { input: input_files=input_files,
                             output_file=output_file,
                             billing_project=billing_project,
                             workspace=workspace,
                             force_samples = force_samples,
-                            print_header = print_header,
-                            cpu=cpu,
-                            memory=memory,
-                            preemptible=preemptible }
+                            print_header = print_header }
 }

--- a/vcf_merge.wdl
+++ b/vcf_merge.wdl
@@ -6,10 +6,10 @@ task xVCFMerge {
         String output_file
         String billing_project
         String workspace
-        Int? addl_disk_space = 1
-        Int? cpu = 8
-        Int? memory = 64
-        Int? preemptible = 0
+        Int addl_disk_space = 1
+        Int cpu = 8
+        Int memory = 64
+        Int preemptible = 0
     }
     Int input_size = ceil(size(input_files, "GB"))
     Int final_disk_size = input_size + addl_disk_space
@@ -33,9 +33,9 @@ workflow xVCFMergeWorkflow {
         String output_file
         String billing_project
         String workspace
-        Int? cpu = 8
-        Int? memory = 64
-        Int? preemptible = 0
+        Int? cpu
+        Int? memory
+        Int? preemptible
     }
     call xVCFMerge { input: input_files=input_files,
                             output_file=output_file,


### PR DESCRIPTION
I successfully tested --print-header and it prints just the header as expected, but I don't know of a vcf that will let me test the other one.

This PR also contains the fixes in https://github.com/DataBiosphere/xvcfmerge/pull/32