### PR TITLE
.dockstore.yml authorship information

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -5,4 +5,9 @@ workflows:
      testParameterFiles:
          - /tests/gs.json
          - /tests/drs.json
+     authors:
+      - name: Brian Hannafious
+      - name: Lon Blauvelt
+        email: lblauvel at ucsc dot edu
+        affiliation: UC Santa Cruz
      name: xvcfmerge


### PR DESCRIPTION
Since we're telling people to put authors in .dockstore.yml files, might as well practice what we preach.

I think dockstore prefers actually writing out full email addresses but I left it how Lon wrote it on the readme just in case.